### PR TITLE
Separate player rotation movement and forward movement actions

### DIFF
--- a/DarkerDungeon.java
+++ b/DarkerDungeon.java
@@ -218,80 +218,16 @@ class Map{
     public void movePlayer(PlayerMovements myMove){
         switch(playerFront){
             case Directions.NORTH:
-                switch(myMove){
-                    case PlayerMovements.FORWARD:
-                        currentLocationY--;
-                        break;
-                    case PlayerMovements.LEFT:
-                        currentLocationX--;
-                        playerFront = Directions.WEST;
-                        break;
-                    case PlayerMovements.BACKWARD:
-                        currentLocationY++;
-                        playerFront = Directions.SOUTH;
-                        break;
-                    case PlayerMovements.RIGHT:
-                        currentLocationX++;
-                        playerFront = Directions.EAST;
-                        break;
-                }
+                currentLocationY--;
                 break;
             case Directions.EAST:
-                switch(myMove){
-                    case PlayerMovements.FORWARD:
-                        currentLocationX++;
-                        break;
-                    case PlayerMovements.LEFT:
-                        currentLocationY--;
-                        playerFront = Directions.NORTH;
-                        break;
-                    case PlayerMovements.BACKWARD:
-                        currentLocationX--;
-                        playerFront = Directions.WEST;
-                        break;
-                    case PlayerMovements.RIGHT:
-                        currentLocationY++;
-                        playerFront = Directions.SOUTH;
-                        break;
-                }
+                currentLocationX++;
                 break;
             case Directions.SOUTH:
-                switch(myMove){
-                    case PlayerMovements.FORWARD:
-                        currentLocationY++;
-                        break;
-                    case PlayerMovements.LEFT:
-                        currentLocationX++;
-                        playerFront = Directions.EAST;
-                        break;
-                    case PlayerMovements.BACKWARD:
-                        currentLocationY--;
-                        playerFront = Directions.NORTH;
-                        break;
-                    case PlayerMovements.RIGHT:
-                        currentLocationX--;
-                        playerFront = Directions.WEST;
-                        break;
-                }
+                 currentLocationY++;
                 break;
             case Directions.WEST:
-                switch(myMove){
-                    case PlayerMovements.FORWARD:
-                        currentLocationX--;
-                        break;
-                    case PlayerMovements.LEFT:
-                        currentLocationY++;
-                        playerFront = Directions.SOUTH;
-                        break;
-                    case PlayerMovements.BACKWARD:
-                        currentLocationX++;
-                        playerFront = Directions.EAST;
-                        break;
-                    case PlayerMovements.RIGHT:
-                        currentLocationY--;
-                        playerFront = Directions.NORTH;
-                        break;
-                }
+                currentLocationX--;
                 break;
         }
     }

--- a/DarkerDungeon.java
+++ b/DarkerDungeon.java
@@ -72,13 +72,10 @@ class Menu{
                         System.out.println(MenuOptions.FORWARD.ordinal() + ": Walk Forward");
                         break;
                     case MenuOptions.LEFT:
-                        System.out.println(MenuOptions.LEFT.ordinal() + ": Walk Left");
+                        System.out.println(MenuOptions.LEFT.ordinal() + ": Turn Left");
                         break;
                     case MenuOptions.RIGHT:
-                        System.out.println(MenuOptions.RIGHT.ordinal() + ": Walk Right");
-                        break;
-                    case MenuOptions.BACKWARD:
-                        System.out.println(MenuOptions.BACKWARD.ordinal() + ": Backtrack");
+                        System.out.println(MenuOptions.RIGHT.ordinal() + ": Turn Right");
                         break;
                     case MenuOptions.OPENDOOR:
                         System.out.println(MenuOptions.OPENDOOR.ordinal() + ": Open Door");

--- a/DarkerDungeon.java
+++ b/DarkerDungeon.java
@@ -167,7 +167,6 @@ class Menu{
         unlockedOptions.set(MenuOptions.OPENDOOR.ordinal(), myMap.checkExit());
         unlockedOptions.set(MenuOptions.FORWARD.ordinal(), myMap.checkPlayerFORWARD());
         unlockedOptions.set(MenuOptions.LEFT.ordinal(), myMap.checkPlayerLEFT());
-        unlockedOptions.set(MenuOptions.BACKWARD.ordinal(), myMap.checkPlayerBACKWARD());
         unlockedOptions.set(MenuOptions.RIGHT.ordinal(), myMap.checkPlayerRIGHT());
     }
 

--- a/DarkerDungeon.java
+++ b/DarkerDungeon.java
@@ -126,7 +126,7 @@ class Menu{
         switch(userOption){
             case FORWARD:
                 System.out.println("\nYou decide to walk for a bit\n");
-                myMap.movePlayer(Map.PlayerMovements.FORWARD);
+                myMap.movePlayer();
                 break;
             case TURNLEFT:
                 System.out.println("\nYou decide to turn left\n");

--- a/DarkerDungeon.java
+++ b/DarkerDungeon.java
@@ -130,11 +130,11 @@ class Menu{
                 break;
             case MenuOptions.TURNLEFT:
                 System.out.println("\nYou decide to turn left\n");
-                myMap.movePlayer(Map.PlayerMovements.TURNLEFT);
+                myMap.turnPlayerLeft();
                 break;
             case MenuOptions.TURNRIGHT:
                 System.out.println("\nYou decide to turn right\n");
-                myMap.movePlayer(Map.PlayerMovements.TURNRIGHT);
+                myMap.turnPlayerRight();
                 break;
             case MenuOptions.DONOTHING:
                 System.out.println("\nYou decide to do nothing for a while\n");
@@ -225,6 +225,48 @@ class Map{
                 break;
             case Directions.WEST:
                 currentLocationX--;
+                break;
+        }
+    }
+
+    /**
+     * @brief Function to update the players direction for a 90 degree
+     *        left turn
+     */
+    public void turnPlayerLeft(){
+        switch(playerFront){
+            case Directions.NORTH:
+                playerFront = Directions.WEST;
+                break;
+            case Directions.EAST:
+                playerFront = Directions.NORTH;
+                break;
+            case Directions.SOUTH:
+                 playerFront = Directions.EAST;
+                break;
+            case Directions.WEST:
+                playerFront = Directions.SOUTH;
+                break;
+        }
+    }
+
+    /**
+     * @brief Function to update the players direction for a 90 degree
+     *        right turn
+     */
+    public void turnPlayerRight(){
+        switch(playerFront){
+            case Directions.NORTH:
+                playerFront = Directions.EAST;
+                break;
+            case Directions.EAST:
+                playerFront = Directions.SOUTH;
+                break;
+            case Directions.SOUTH:
+                 playerFront = Directions.WEST;
+                break;
+            case Directions.WEST:
+                playerFront = Directions.NORTH;
                 break;
         }
     }

--- a/DarkerDungeon.java
+++ b/DarkerDungeon.java
@@ -41,7 +41,7 @@ public class main{
  * @brief Menu class that holds game state information about the program
  */
 class Menu{
-    public enum MenuOptions { ZERO, DONOTHING, FORWARD, LEFT, RIGHT, BACKWARD, OPENDOOR, END}
+    public enum MenuOptions { ZERO, DONOTHING, FORWARD, TURNLEFT, TURNRIGHT, OPENDOOR, END}
     ArrayList<Boolean> unlockedOptions;
     private Map myMap;
 

--- a/DarkerDungeon.java
+++ b/DarkerDungeon.java
@@ -65,19 +65,19 @@ class Menu{
             MenuOptions index = MenuOptions.values()[i];
             if(unlockedOptions.get(i)){
                 switch(index){
-                    case MenuOptions.DONOTHING:
+                    case DONOTHING:
                         System.out.println(MenuOptions.DONOTHING.ordinal() + ": Do Nothing");
                         break;
-                    case MenuOptions.FORWARD:
+                    case FORWARD:
                         System.out.println(MenuOptions.FORWARD.ordinal() + ": Walk Forward");
                         break;
-                    case MenuOptions.TURNLEFT:
+                    case TURNLEFT:
                         System.out.println(MenuOptions.TURNLEFT.ordinal() + ": Turn Left");
                         break;
-                    case MenuOptions.TURNRIGHT:
+                    case TURNRIGHT:
                         System.out.println(MenuOptions.TURNRIGHT.ordinal() + ": Turn Right");
                         break;
-                    case MenuOptions.OPENDOOR:
+                    case OPENDOOR:
                         System.out.println(MenuOptions.OPENDOOR.ordinal() + ": Open Door");
                         break;
                     default:
@@ -124,22 +124,22 @@ class Menu{
      */
     public Boolean printAndDoResponse(MenuOptions userOption){
         switch(userOption){
-            case MenuOptions.FORWARD:
+            case FORWARD:
                 System.out.println("\nYou decide to walk for a bit\n");
                 myMap.movePlayer(Map.PlayerMovements.FORWARD);
                 break;
-            case MenuOptions.TURNLEFT:
+            case TURNLEFT:
                 System.out.println("\nYou decide to turn left\n");
                 myMap.turnPlayerLeft();
                 break;
-            case MenuOptions.TURNRIGHT:
+            case TURNRIGHT:
                 System.out.println("\nYou decide to turn right\n");
                 myMap.turnPlayerRight();
                 break;
-            case MenuOptions.DONOTHING:
+            case DONOTHING:
                 System.out.println("\nYou decide to do nothing for a while\n");
                 break;
-            case MenuOptions.OPENDOOR:
+            case OPENDOOR:
                 System.out.println("     \\       /");
                 System.out.println("      \\_ _ _/");
                 System.out.println("      /  _  \\ ");
@@ -214,16 +214,16 @@ class Map{
      */
     public void movePlayer(){
         switch(playerFront){
-            case Directions.NORTH:
+            case NORTH:
                 currentLocationY--;
                 break;
-            case Directions.EAST:
+            case EAST:
                 currentLocationX++;
                 break;
-            case Directions.SOUTH:
+            case SOUTH:
                  currentLocationY++;
                 break;
-            case Directions.WEST:
+            case WEST:
                 currentLocationX--;
                 break;
         }
@@ -235,16 +235,16 @@ class Map{
      */
     public void turnPlayerLeft(){
         switch(playerFront){
-            case Directions.NORTH:
+            case NORTH:
                 playerFront = Directions.WEST;
                 break;
-            case Directions.EAST:
+            case EAST:
                 playerFront = Directions.NORTH;
                 break;
-            case Directions.SOUTH:
+            case SOUTH:
                  playerFront = Directions.EAST;
                 break;
-            case Directions.WEST:
+            case WEST:
                 playerFront = Directions.SOUTH;
                 break;
         }
@@ -256,16 +256,16 @@ class Map{
      */
     public void turnPlayerRight(){
         switch(playerFront){
-            case Directions.NORTH:
+            case NORTH:
                 playerFront = Directions.EAST;
                 break;
-            case Directions.EAST:
+            case EAST:
                 playerFront = Directions.SOUTH;
                 break;
-            case Directions.SOUTH:
+            case SOUTH:
                  playerFront = Directions.WEST;
                 break;
-            case Directions.WEST:
+            case WEST:
                 playerFront = Directions.NORTH;
                 break;
         }
@@ -289,19 +289,19 @@ class Map{
      */
     public Boolean checkPlayerFORWARD(){
         switch (playerFront){
-            case Directions.NORTH:
+            case NORTH:
                 if(currentLocationY > 0)
                     return true;
                 break;
-            case Directions.WEST:
+            case WEST:
                 if(currentLocationX > 0)
                     return true;
                 break;
-            case Directions.SOUTH:
+            case SOUTH:
                 if(currentLocationY < height)
                     return true;
                 break;
-            case Directions.EAST:
+            case EAST:
                 if(currentLocationX < width)
                     return true;
                 break;

--- a/DarkerDungeon.java
+++ b/DarkerDungeon.java
@@ -166,8 +166,6 @@ class Menu{
     public void updateMenu(){
         unlockedOptions.set(MenuOptions.OPENDOOR.ordinal(), myMap.checkExit());
         unlockedOptions.set(MenuOptions.FORWARD.ordinal(), myMap.checkPlayerFORWARD());
-        unlockedOptions.set(MenuOptions.LEFT.ordinal(), myMap.checkPlayerLEFT());
-        unlockedOptions.set(MenuOptions.RIGHT.ordinal(), myMap.checkPlayerRIGHT());
     }
 
     public void clearScreen() {
@@ -184,7 +182,6 @@ class Menu{
  */
 class Map{
     private enum Directions { NORTH, EAST, SOUTH, WEST }
-    public enum PlayerMovements {FORWARD, LEFT, BACKWARD, RIGHT}
     private int width;
     private int height;
     private Directions playerFront;
@@ -212,10 +209,10 @@ class Map{
     }
 
     /**
-     * @brief Function to update player information based on a requested move action
+     * @brief Function to update player location to be 1 square forward
      * @apiNote Warning this function does not do bounds checking for you
      */
-    public void movePlayer(PlayerMovements myMove){
+    public void movePlayer(){
         switch(playerFront){
             case Directions.NORTH:
                 currentLocationY--;
@@ -269,86 +266,5 @@ class Map{
         }
 
         return  false;
-    }
-
-    /**
-     * @brief Function to check if the player can move left
-     * @return boolean based on if the player can move left or not
-     */
-    public Boolean checkPlayerLEFT(){
-        switch (playerFront){
-            case Directions.NORTH:
-                if(currentLocationX > 0)
-                    return true;
-                break;
-            case Directions.WEST:
-                if(currentLocationY < height)
-                    return true;
-                break;
-            case Directions.SOUTH:
-                if(currentLocationX < width)
-                    return true;
-                break;
-            case Directions.EAST:
-                if(currentLocationY > 0)
-                    return true;
-                break;
-        }
-
-        return false;
-    }
-
-    /**
-     * @brief Function to check if the player can move backward
-     * @return boolean based on if the player can move backward or not
-     */
-    public Boolean checkPlayerBACKWARD(){
-        switch (playerFront){
-            case Directions.NORTH:
-                if(currentLocationY < height)
-                    return true;
-                break;
-            case Directions.WEST:
-                if(currentLocationX < width)
-                    return true;
-                break;
-            case Directions.SOUTH:
-                if(currentLocationY > 0)
-                    return true;
-                break;
-            case Directions.EAST:
-                if(currentLocationX > 0)
-                    return true;
-                break;
-        }
-
-        return false;
-    }
-
-    /**
-     * @brief Function to check if the player can move right
-     * @return boolean based on if the player can move tight or not
-     */
-    public Boolean checkPlayerRIGHT(){
-        switch (playerFront){
-            case Directions.NORTH:
-                if(currentLocationX < width)
-                    return true;
-                break;
-            case Directions.WEST:
-                if(currentLocationY > 0)
-                    return true;
-                break;
-            case Directions.SOUTH:
-                if(currentLocationX > 0)
-                    return true;
-                break;
-            case Directions.EAST:
-                if(currentLocationY < height)
-                    return true;
-                break;
-        }
-
-        return false;
     }
 }

--- a/DarkerDungeon.java
+++ b/DarkerDungeon.java
@@ -129,16 +129,12 @@ class Menu{
                 myMap.movePlayer(Map.PlayerMovements.FORWARD);
                 break;
             case MenuOptions.LEFT:
-                System.out.println("\nYou decide to turn left and walk for a bit\n");
+                System.out.println("\nYou decide to turn left\n");
                 myMap.movePlayer(Map.PlayerMovements.LEFT);
                 break;
             case MenuOptions.RIGHT:
-                System.out.println("\nYou decide to turn right and walk for a bit\n");
+                System.out.println("\nYou decide to turn right\n");
                 myMap.movePlayer(Map.PlayerMovements.RIGHT);
-                break;
-            case MenuOptions.BACKWARD:
-                System.out.println("\nYou decide to turn around and walk for a bit\n");
-                myMap.movePlayer(Map.PlayerMovements.BACKWARD);
                 break;
             case MenuOptions.DONOTHING:
                 System.out.println("\nYou decide to do nothing for a while\n");

--- a/DarkerDungeon.java
+++ b/DarkerDungeon.java
@@ -71,11 +71,11 @@ class Menu{
                     case MenuOptions.FORWARD:
                         System.out.println(MenuOptions.FORWARD.ordinal() + ": Walk Forward");
                         break;
-                    case MenuOptions.LEFT:
-                        System.out.println(MenuOptions.LEFT.ordinal() + ": Turn Left");
+                    case MenuOptions.TURNLEFT:
+                        System.out.println(MenuOptions.TURNLEFT.ordinal() + ": Turn Left");
                         break;
-                    case MenuOptions.RIGHT:
-                        System.out.println(MenuOptions.RIGHT.ordinal() + ": Turn Right");
+                    case MenuOptions.TURNRIGHT:
+                        System.out.println(MenuOptions.TURNRIGHT.ordinal() + ": Turn Right");
                         break;
                     case MenuOptions.OPENDOOR:
                         System.out.println(MenuOptions.OPENDOOR.ordinal() + ": Open Door");
@@ -128,13 +128,13 @@ class Menu{
                 System.out.println("\nYou decide to walk for a bit\n");
                 myMap.movePlayer(Map.PlayerMovements.FORWARD);
                 break;
-            case MenuOptions.LEFT:
+            case MenuOptions.TURNLEFT:
                 System.out.println("\nYou decide to turn left\n");
-                myMap.movePlayer(Map.PlayerMovements.LEFT);
+                myMap.movePlayer(Map.PlayerMovements.TURNLEFT);
                 break;
-            case MenuOptions.RIGHT:
+            case MenuOptions.TURNRIGHT:
                 System.out.println("\nYou decide to turn right\n");
-                myMap.movePlayer(Map.PlayerMovements.RIGHT);
+                myMap.movePlayer(Map.PlayerMovements.TURNRIGHT);
                 break;
             case MenuOptions.DONOTHING:
                 System.out.println("\nYou decide to do nothing for a while\n");


### PR DESCRIPTION
- This allows for the player to now choose to just rotate left and right to turn 90 degrees instead of being forced to move a square forward while doing this action. 
- This update removes the ability to move in other directions besides forward.